### PR TITLE
README instructions to run project for first time

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,20 @@
 # web-app
+
+First Run
+-----------------------
+1. If on a Mac first install [Xcode](https://developer.apple.com/xcode/downloads/)
+2. Install [MongoDB](https://www.mongodb.org/downloads)
+2. [Install Node.js](http://nodejs.org/download/)
+3. Globally install Grunt, Yeoman, and Bower:
+
+        $ npm install -g grunt-cli
+        $ npm install -g yo
+        $ npm install -g bower
+
+4. Navigate to the web-app directory
+5. Install npm and bower dependencies:
+
+        $ bower install
+        $ npm install
+6. Use ``grunt serve`` to run the application.
+


### PR DESCRIPTION
Using 8 spaces instead of 4 for code blocks due to a Markdown bug where code blocks don't work properly when used inside an ordered list. These instructions were tested on a Mac, they should work properly on Windows as well.